### PR TITLE
fix: incorrect latency values in fixed --qps load test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,27 @@ Please note that the unit of time for all below terminal commands is seconds.
 ### Running a single load test
 To run the container with default arguments (`qps=20`, `duration=5`):
 ```bash
-docker run http-load-tester http://example.com
+docker run http-load-tester --url http://example.com
 ```
 
 To run the container with custom arguments:
 ```bash
-docker run http-load-tester http://example.com --qps 20 --duration 5
+docker run http-load-tester --url http://example.com --qps 5 --duration 5
 ```
 
 An example output of the above command is below:
 ```txt
 Results for http://example.com
-Total requests: 100
+Total requests: 25
 Total errors: 0
 Error rate: 0.000%
-Mean latency: 47.345 milliseconds
-Median latency: 41.492 milliseconds
-Min latency: 15.457 milliseconds
-Max latency: 121.339 milliseconds
+Mean latency: 18.347 milliseconds
+Median latency: 17.637 milliseconds
+Min latency: 11.618 milliseconds
+Max latency: 40.071 milliseconds
 
 Status code distribution:
-  200: 100
+  200: 25
 ```
 
 ### Automatically finding the breaking point of the server
@@ -46,55 +46,55 @@ If you'd like to find the highest qps (queries per second) that the server can h
 
 You can change the url, duration, max qps, max error rate, and max latency as needed. 
 ```bash
- docker run http-load-tester http://apple.com --find-breaking-point --duration=8 --max-qps 1000 --max-error-rate 0.01 --max-latency 0.5
+docker run http-load-tester --url http://192.168.111.28:8000 --find-breaking-point --duration=5 --max-qps 1000 --max-error-rate 0.01 --max-latency 0.5
 ```
 
 An example output of this command is:
 ```txt
 Beginning search for breaking point.
-Tested QPS: 500, Error Rate: 0.00%, Mean Latency: 3.517s
-Tested QPS: 250, Error Rate: 0.00%, Mean Latency: 1.974s
-Tested QPS: 125, Error Rate: 0.00%, Mean Latency: 1.188s
-Tested QPS: 62, Error Rate: 0.00%, Mean Latency: 0.703s
-Tested QPS: 31, Error Rate: 0.00%, Mean Latency: 0.372s
-Tested QPS: 46, Error Rate: 0.00%, Mean Latency: 0.496s
-Tested QPS: 54, Error Rate: 0.00%, Mean Latency: 0.602s
-Tested QPS: 50, Error Rate: 0.00%, Mean Latency: 0.577s
-Tested QPS: 48, Error Rate: 0.00%, Mean Latency: 0.536s
-Tested QPS: 47, Error Rate: 0.00%, Mean Latency: 0.521s
+Tested QPS: 500, Error Rate: 0.12%, Mean Latency: 0.026s
+Tested QPS: 750, Error Rate: 0.16%, Mean Latency: 0.033s
+Tested QPS: 875, Error Rate: 0.11%, Mean Latency: 0.027s
+Tested QPS: 938, Error Rate: 0.15%, Mean Latency: 0.042s
+Tested QPS: 969, Error Rate: 0.14%, Mean Latency: 0.030s
+Tested QPS: 985, Error Rate: 0.14%, Mean Latency: 0.035s
+Tested QPS: 993, Error Rate: 0.10%, Mean Latency: 0.040s
+Tested QPS: 997, Error Rate: 0.12%, Mean Latency: 0.028s
+Tested QPS: 999, Error Rate: 0.12%, Mean Latency: 0.030s
+Tested QPS: 1000, Error Rate: 0.32%, Mean Latency: 0.073s
 
-Breaking point found: 46 QPS
+Breaking point not found within range. The server had adequate performance at all levels of queries per second tested.
 
 Final test results:
-Results for http://apple.com
-Total requests: 368
-Total errors: 0
-Error rate: 0.000%
-Mean latency: 476.503 milliseconds
-Median latency: 449.405 milliseconds
-Min latency: 180.404 milliseconds
-Max latency: 1268.814 milliseconds
+Results for http://192.168.111.28:8000
+Total requests: 5000
+Total errors: 7
+Error rate: 0.140%
+Mean latency: 31.362 milliseconds
+Median latency: 7.566 milliseconds
+Min latency: 4.511 milliseconds
+Max latency: 15017.129 milliseconds
 
 Status code distribution:
-  200: 368
+  200: 4993
+  error: 7
 ```
 
 ## CLI documentation
 The documentation for the CLI is below. 
 ```txt
-usage: load_tester.py [-h] [--qps QPS] [--duration DURATION]
+
+usage: load_tester.py [-h] [--url URL] [--qps QPS] [--duration DURATION]
                       [--find-breaking-point] [--max-qps MAX_QPS]
                       [--max-error-rate MAX_ERROR_RATE]
-                      [--max-latency MAX_LATENCY]
-                      url
+                      [--max-latency MAX_LATENCY] [--verbose]
+                      [--retries RETRIES]
 
 HTTP Load Testing Tool
 
-positional arguments:
-  url                   Target URL to test
-
 optional arguments:
   -h, --help            show this help message and exit
+  --url URL             Target URL to test
   --qps QPS             Queries per second for a single test
   --duration DURATION   Test duration in seconds
   --find-breaking-point
@@ -107,4 +107,7 @@ optional arguments:
   --max-latency MAX_LATENCY
                         Maximum acceptable mean latency in seconds when
                         finding breaking point
+  --verbose             Print verbose output including error messages
+  --retries RETRIES     Number of retry attempts for a failed request
+
 ```

--- a/app/load_test_stats.py
+++ b/app/load_test_stats.py
@@ -16,6 +16,7 @@ class LoadTestStats:
         self.median_latency = -1
         self.min_latency = -1
         self.max_latency = -1
+        self.error_set = set()
 
     def add_result(self, status: str, latency: float) -> None:
         """Add a single result to the stats."""

--- a/app/load_tester.py
+++ b/app/load_tester.py
@@ -1,44 +1,54 @@
 import asyncio
 import sys
-
 import aiohttp
 import argparse
 import time
-from typing import List, Tuple, Optional
+from typing import Tuple, Optional
 
 from app.load_test_stats import LoadTestStats
-
 
 class HTTPLoadTester:
     """A class for performing HTTP load testing and optionally determining server breaking point."""
 
-    def __init__(self, url: str, qps: Optional[int] = None) -> None:
+    def __init__(self, url: str, qps: Optional[int] = None, verbose: bool = False, retries: int = 5) -> None:
         """
         Initialize the HTTPLoadTester.
 
         Args:
             url (str): The URL to test.
             qps (Optional[int]): The number of queries per second to perform (if running a single test).
+            verbose (bool): Whether to print verbose output.
+            retries (int): Number of retry attempts for a failed request.
         """
         self.url: str = url
         self.qps: Optional[int] = qps
+        self.verbose: bool = verbose
+        self.retries: int = retries
         self.load_test_stats = LoadTestStats()
 
     async def make_request(self, session: aiohttp.ClientSession) -> None:
         """
-        Make a single HTTP request and record the results.
+        Make a single HTTP request and record the results with retry logic.
 
         Args:
             session (aiohttp.ClientSession): The session to use for the request.
         """
         start_time: float = time.perf_counter()
-        try:
-            async with session.get(self.url) as response:
-                await response.text()
-                latency: float = time.perf_counter() - start_time
-                self.load_test_stats.results[str(response.status)].append(latency)
-        except Exception:
-            self.load_test_stats.results['error'].append(time.perf_counter() - start_time)
+        for attempt in range(self.retries):
+            try:
+                async with session.get(self.url) as response:
+                    latency: float = time.perf_counter() - start_time
+                    await response.text()
+                    self.load_test_stats.results[str(response.status)].append(latency)
+                    return
+            except Exception as e:
+                if attempt < self.retries - 1:
+                    await asyncio.sleep(2 ** attempt)  # Exponential backoff
+                else:
+                    self.load_test_stats.results['error'].append(time.perf_counter() - start_time)
+                    self.load_test_stats.error_set.add(str(e))
+                    if self.verbose: 
+                        print("Error received from request:", str(e))
 
     async def generate_load(self, duration: int, qps: Optional[int] = None) -> None:
         """
@@ -53,14 +63,23 @@ class HTTPLoadTester:
             raise ValueError("QPS must be specified either in the constructor or as a method argument")
 
         async with aiohttp.ClientSession() as session:
-            end_time = time.time() + duration
+            start_time = time.time()
+            end_time = start_time + duration
+            interval = 1 / qps
+            next_request_time = start_time
+
             while time.time() < end_time:
-                start_time: float = time.time()
-                tasks: List[asyncio.Task] = [asyncio.create_task(self.make_request(session)) for _ in range(qps)]
-                await asyncio.gather(*tasks)
-                elapsed: float = time.time() - start_time
-                if elapsed < 1:
-                    await asyncio.sleep(1 - elapsed)
+                current_time = time.time()
+                if current_time >= next_request_time:
+                    if current_time < end_time:
+                        asyncio.create_task(self.make_request(session))
+                        next_request_time += interval
+                    await asyncio.sleep(0)  # Yield control to allow other tasks to run
+                else:
+                    await asyncio.sleep(next_request_time - current_time)
+
+        # Wait for any remaining tasks to complete
+        await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 
     async def run_test(self, duration: int, qps: Optional[int] = None) -> Tuple[float, float]:
         """
@@ -136,40 +155,37 @@ class HTTPLoadTester:
         for status, count in self.load_test_stats.status_distribution.items():
             print(f"  {status}: {count}")
 
+    async def run(self, args: argparse.Namespace) -> None:
+        """Run the load test or find the breaking point based on the provided arguments."""
+        try:
+            if args.find_breaking_point:
+                await self.find_breaking_point(args.max_qps, args.duration, args.max_error_rate, args.max_latency)
+            else:
+                await self.run_test(args.duration)
+                self.print_results()
+        finally:
+            tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+            await asyncio.gather(*tasks, return_exceptions=True)
 
-async def main() -> None:
-    """Parse command line arguments and run the load test."""
+def parse_arguments():
     parser: argparse.ArgumentParser = argparse.ArgumentParser(description="HTTP Load Testing Tool")
-    parser.add_argument("url", help="Target URL to test")
+    parser.add_argument("--url", default="http://example.com", help="Target URL to test")
     parser.add_argument("--qps", type=int, default=20, help="Queries per second for a single test")
     parser.add_argument("--duration", type=int, default=5, help="Test duration in seconds")
     parser.add_argument("--find-breaking-point", action="store_true", help="Find the breaking point of the server")
-    parser.add_argument("--max-qps", type=int, default=1000,
-                        help="Maximum queries per second to test when finding breaking point")
-    parser.add_argument("--max-error-rate", type=float, default=0.01,
-                        help="Maximum acceptable error rate when finding breaking point")
-    parser.add_argument("--max-latency", type=float, default=0.5,
-                        help="Maximum acceptable mean latency in seconds when finding breaking point")
-    args: argparse.Namespace = parser.parse_args()
+    parser.add_argument("--max-qps", type=int, default=1000, help="Maximum queries per second to test when finding breaking point")
+    parser.add_argument("--max-error-rate", type=float, default=0.01, help="Maximum acceptable error rate when finding breaking point")
+    parser.add_argument("--max-latency", type=float, default=0.5, help="Maximum acceptable mean latency in seconds when finding breaking point")
+    parser.add_argument("--verbose", action="store_true", help="Print verbose output including error messages")
+    parser.add_argument("--retries", type=int, default=5, help="Number of retry attempts for a failed request")
+    return parser.parse_args()
 
-    tester: HTTPLoadTester = HTTPLoadTester(args.url, args.qps)
-
-    try:
-        if args.find_breaking_point:
-            await tester.find_breaking_point(args.max_qps, args.duration, args.max_error_rate,
-                                             args.max_latency)
-        else:
-            await tester.run_test(args.duration)
-            tester.print_results()
-    finally:
-        # Ensure all pending tasks are completed
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-        await asyncio.gather(*tasks, return_exceptions=True)
-
+async def main() -> None:
+    args = parse_arguments()
+    tester = HTTPLoadTester(args.url, args.qps, args.verbose, args.retries)
+    await tester.run(args)
 
 if __name__ == "__main__":
     if sys.platform.startswith('win'):
-        # Set the event loop policy to WindowsSelectorEventLoopPolicy on Windows
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     asyncio.run(main())


### PR DESCRIPTION
The `generate_load`() function originally bunched up all requests in the beginning of each duration window. This meant that the server would get flooded with requests in the beginning of the load test, rather than the requests being spread evenly over the duration window. This is why the latency values were higher than they should have been. Now, the requests are timed and sent at even intervals over the course of each second of the load test. 